### PR TITLE
Fix logic for getting extension from file name

### DIFF
--- a/headers/Helper.h
+++ b/headers/Helper.h
@@ -29,15 +29,15 @@ class Helper {
     Helper();   //Disallow creating an instance
 
     public:
-    static bool validateFileName(string fileName);
-    static bool fileExist(string fileName);
+    static bool validateFileName(const string& fileName);
+    static bool fileExist(const string& fileName);
     static bool questionReceptor(string answer);
     static string getDataPath();
 
-    static string getExtension(string fileName);
-    static string getNameOfFile(string fileName);
-    static void replaceClassName(string& className, string fileName);
-    static bool RequireHeaderAssistance(string fileName, string &initCommentChar, string &finalCommentChar);
+    static string getExtension(const string& fileName);
+    static string getNameOfFile(const string& fileName);
+    static void replaceClassName(string& className, const string& fileName);
+    static bool RequireHeaderAssistance(const string& fileName, string &initCommentChar, string &finalCommentChar);
 };
 
 #endif

--- a/src/Helper.cpp
+++ b/src/Helper.cpp
@@ -9,7 +9,7 @@
 
 using namespace std;
 
-bool Helper::validateFileName(string fileName)
+bool Helper::validateFileName(const string& fileName)
 // validateFileName: receives the file name string and evaluates if its a correct format
 // returns: true if is correct false otherwise.
 {
@@ -24,7 +24,7 @@ bool Helper::validateFileName(string fileName)
     return result;
 }
 
-bool Helper::fileExist(string fileName) {
+bool Helper::fileExist(const string& fileName) {
     ifstream file;
     bool state = false;
     try {
@@ -49,23 +49,23 @@ bool Helper::questionReceptor(string answer) {
 }
 
 
-string Helper::getExtension(string fileName) {
+string Helper::getExtension(const string& fileName) {
     string ext;
-    size_t dotPosition = fileName.find(".");
+    size_t dotPosition = fileName.rfind('.');
     ext = fileName.substr(dotPosition);
     return ext;
 }
 
-string Helper::getNameOfFile(string fileName) {
+string Helper::getNameOfFile(const string& fileName) {
     string name;
-	size_t dotPosition = fileName.find(".");
+	size_t dotPosition = fileName.rfind('.');
 	name = fileName.substr(0, dotPosition);
     return name;
 }
 
 
 
-void Helper::replaceClassName(string& className, string fileName) {
+void Helper::replaceClassName(string& className, const string& fileName) {
 	const string CLASSNAMETMPL = "HelloWorld";
 	int si_ze = CLASSNAMETMPL.length();
 	string nameFile = getNameOfFile(fileName);
@@ -84,12 +84,12 @@ string Helper::getDataPath() {
     return dataPath;
 }
 
-bool Helper::RequireHeaderAssistance(string fileName, string &initCommentChar, string &finalCommentChar){
+bool Helper::RequireHeaderAssistance(const string& fileName, string &initCommentChar, string &finalCommentChar){
     bool decisionFlag;
-    
+
     cout << "The program does not recognize the extension associated to the file: '" << fileName;
     cout << "'. Do you want to add a header comment to this unknown file (y/n): ";
-    string decision = "";
+    string decision;
     cin >> decision;
     decisionFlag = questionReceptor(decision);
     if (decisionFlag) {


### PR DESCRIPTION
### Description

<!--- Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change. --->

Change logic for getting extension from a filename.
Now it will consider the last '.' to split the filename

For example, in *main.runner.py*, *py* is considered as extension.

### Type of Change:

<!--- **Delete irrelevant options.** --->

- Code:
    - [x] Bug fix (non-breaking change which fixes an issue)
    - [ ] This change requires a documentation update (software upgrade on readme file)
    - [ ] New feature (non-breaking change which adds functionality pre-approved by consensus)
- User Interface
- Documentation




### How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test. -->


### Checklist:

<!-- **Delete irrelevant options.** -->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
